### PR TITLE
Bump minimum CMake version to 3.8.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake version check.
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.8)
 
 # Set default build type to "Release".
 # NOTE: this should be done before the project command since the latter can set

--- a/cmake_modules/yacma/LICENSE
+++ b/cmake_modules/yacma/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2019 Francesco Biscani
+Copyright (c) 2016-2020 Francesco Biscani
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Audi requires C++17, but setting the C++ standard to 17 is supported only since CMake 3.8.